### PR TITLE
pkgs.aw-server-rust: init at unstable-2021-04-22

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -16,6 +16,26 @@
         "type": "github"
       }
     },
+    "naersk": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1618844365,
+        "narHash": "sha256-Z9t0rr+5OG/ru3jdg3jivfYVU4ydV/nqt8UwIut7uHs=",
+        "owner": "nmattia",
+        "repo": "naersk",
+        "rev": "32e3ba39d9d83098b13720a4384bdda191dd0445",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nmattia",
+        "repo": "naersk",
+        "type": "github"
+      }
+    },
     "napalm": {
       "inputs": {
         "nixpkgs": [
@@ -68,12 +88,31 @@
         "type": "github"
       }
     },
+    "nixpkgs-mozilla": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1612892239,
+        "narHash": "sha256-jwrdJvaDl+kCRH3LFYuL9KweXO7fCTXxLovKja6xqbk=",
+        "owner": "andersk",
+        "repo": "nixpkgs-mozilla",
+        "rev": "3499e085fb6ae1a846bcf425fa9c98a3b77480da",
+        "type": "github"
+      },
+      "original": {
+        "owner": "andersk",
+        "ref": "stdenv.lib",
+        "repo": "nixpkgs-mozilla",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "flake-compat": "flake-compat",
+        "naersk": "naersk",
         "napalm": "napalm",
         "nixgl": "nixgl",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-mozilla": "nixpkgs-mozilla"
       }
     }
   },

--- a/flake.lock
+++ b/flake.lock
@@ -105,6 +105,22 @@
         "type": "github"
       }
     },
+    "npmlock2nix": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1608299130,
+        "narHash": "sha256-yuwxROMoHIm2yCf9Gyvy2bhzkLxvLaknNI5pw1hvL4I=",
+        "owner": "tweag",
+        "repo": "npmlock2nix",
+        "rev": "7a321e2477d1f97167847086400a7a4d75b8faf8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tweag",
+        "repo": "npmlock2nix",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "flake-compat": "flake-compat",
@@ -112,7 +128,8 @@
         "napalm": "napalm",
         "nixgl": "nixgl",
         "nixpkgs": "nixpkgs",
-        "nixpkgs-mozilla": "nixpkgs-mozilla"
+        "nixpkgs-mozilla": "nixpkgs-mozilla",
+        "npmlock2nix": "npmlock2nix"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -28,9 +28,14 @@
       url = "github:andersk/nixpkgs-mozilla/stdenv.lib";
       flake = false;
     };
+
+    npmlock2nix = {
+      url = "github:tweag/npmlock2nix";
+      flake = false;
+    };
   };
 
-  outputs = { self, flake-compat, naersk, napalm, nixpkgs, nixpkgs-mozilla, nixgl }@inputs:
+  outputs = { self, flake-compat, naersk, napalm, nixpkgs, nixpkgs-mozilla, nixgl, npmlock2nix }@inputs:
     let
       inherit (nixpkgs) lib;
 
@@ -80,6 +85,8 @@
                   cargo = rust;
                   rustc = rust;
                 };
+
+            npmlock2nix = import npmlock2nix { pkgs = prev; };
           })
         ];
         config = {

--- a/pkgs/activitywatch/default.nix
+++ b/pkgs/activitywatch/default.nix
@@ -1,0 +1,46 @@
+{ lib
+, fetchFromGitHub
+, naerskUnstable
+, pkg-config
+, perl
+, openssl
+}:
+
+let
+  version = "unstable-2020-04-22";
+
+  sources = fetchFromGitHub {
+    owner = "ActivityWatch";
+    repo = "activitywatch";
+    rev = "d39648092fa8fa1adff0809b2f9bccdde99537af";
+    sha256 = "3Sz+Vjn20cfD5UnR3pvevX+icU8l//uNMOkfnRp/+NU=";
+    fetchSubmodules = true;
+  };
+
+in
+
+{
+  aw-server-rust = naerskUnstable.buildPackage {
+    pname = "aw-server-rust";
+    inherit version;
+
+    root = "${sources}/aw-server-rust";
+
+    nativeBuildInputs = [
+      pkg-config
+      perl
+    ];
+
+    buildInputs = [
+      openssl
+    ];
+
+    meta = with lib; {
+      description = "Cross-platform, extensible, privacy-focused, free and open-source automated time tracker";
+      homepage = "https://activitywatch.net/";
+      maintainers = with maintainers; [ jtojnar ];
+      platforms = platforms.linux;
+      license = licenses.mpl20;
+    };
+  };
+}

--- a/pkgs/activitywatch/default.nix
+++ b/pkgs/activitywatch/default.nix
@@ -4,6 +4,8 @@
 , pkg-config
 , perl
 , openssl
+, runCommand
+, npmlock2nix
 }:
 
 let
@@ -18,6 +20,10 @@ let
   };
 
 in
+
+# The GUI app is [stuck on Python 3.6](https://github.com/ActivityWatch/activitywatch/issues/491), with which some of our python packages no longer build. I also tried using poetry2nix but without much success. Fortunately, it is not required.
+
+# I did not try to package the Python server due to issues with poetry2nix I encountered for aw-qt and since there is a Rust server available. The Rust server [requires unstable Rust](https://github.com/ActivityWatch/aw-server-rust/issues/116) preventing us to include it in nixpkgs.
 
 {
   aw-server-rust = naerskUnstable.buildPackage {
@@ -35,6 +41,11 @@ in
       openssl
     ];
 
+    postInstall = ''
+      mkdir "$out/bin/aw_server_rust"
+      ln -s "${aw-webui}" "$out/bin/aw_server_rust/static"
+    '';
+
     meta = with lib; {
       description = "Cross-platform, extensible, privacy-focused, free and open-source automated time tracker";
       homepage = "https://activitywatch.net/";
@@ -43,4 +54,23 @@ in
       license = licenses.mpl20;
     };
   };
+
+  aw-webui =
+    let
+      webui-src = runCommand "webui-src" {} ''
+        cp -r "${sources}/aw-server-rust/aw-webui" "$out"
+        chmod +w "$out" "$out/package-lock.json"
+
+        # Bypass query string in URL producing invalid derivation name.
+        # https://github.com/nmattia/napalm/issues/30
+        sed -Ei 's#\?cache=0&other_urls[^"]+##' "$out/package-lock.json"
+
+        # Some packages resolved to Taobao registry, which does not seem to get substituted.
+        sed -Ei 's#https://registry.npm.taobao.org/(.+?)/download/#https://registry.npmjs.org/\1/-/#' "$out/package-lock.json"
+      '';
+    in
+      npmlock2nix.build {
+        src = webui-src;
+        installPhase = "cp -r dist $out";
+      };
 }

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -1,4 +1,7 @@
 final: prev: {
+  inherit (prev.callPackages ./activitywatch { })
+    aw-server-rust;
+
   pengu = prev.callPackage ./pengu {};
 
   phpbb = prev.callPackage ./phpbb {};

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -1,6 +1,7 @@
 final: prev: {
   inherit (prev.callPackages ./activitywatch { })
-    aw-server-rust;
+    aw-server-rust
+    aw-webui;
 
   pengu = prev.callPackage ./pengu {};
 


### PR DESCRIPTION
The GUI app is [stuck on Python 3.6](https://github.com/ActivityWatch/activitywatch/issues/491), with which some of our python packages no longer build. I also tried using poetry2nix but without much success. Fortunately, it is not required.

I did not try to package the Python server due to issues with poetry2nix I encountered for aw-qt and since there is a Rust server available. The Rust server [requires unstable Rust](https://github.com/ActivityWatch/aw-server-rust/issues/116) preventing us to include it in nixpkgs.

