### PR TITLE
activitywatch: unstable-2021-06-23 → 0.12.1

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -106,9 +106,9 @@
               let
                 nmo = import nixpkgs-mozilla final prev;
                 rust = (nmo.rustChannelOf {
-                  date = "2021-06-30";
+                  date = "2022-08-08";
                   channel = "nightly";
-                  sha256 = "d02mYpeoCuv+tf2oFUOGybJ23GzcA9pSyJT8z/7RuSg=";
+                  sha256 = "sha256-r/8YBFuFa4hpwgE3FnME7nQA2Uc1uqj0eCE1NWmI1u0=";
                 }).rust;
               in
                 naersk.lib.${platform}.override {

--- a/pkgs/activitywatch/commit-hash.patch
+++ b/pkgs/activitywatch/commit-hash.patch
@@ -1,0 +1,16 @@
+diff --git a/vue.config.js b/vue.config.js
+index 02c0699..0c4a014 100644
+--- a/vue.config.js
++++ b/vue.config.js
+@@ -4,10 +4,7 @@ const CopyWebpackPlugin = require('copy-webpack-plugin');
+ const { argv } = require('yargs');
+ 
+ // get git info from command line
+-const _COMMIT_HASH = require('child_process')
+-  .execSync('git rev-parse --short HEAD')
+-  .toString()
+-  .trim();
++const _COMMIT_HASH = "@commit_hash@";
+ console.info('Commit hash:', _COMMIT_HASH);
+ 
+ module.exports = {

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -3,6 +3,7 @@ final: prev: {
 
   inherit (prev.callPackages ./activitywatch { })
     aw-core
+    aw-client
     aw-server-rust
     aw-qt
     aw-watcher-afk


### PR DESCRIPTION
Updates dependencies, including rust unstable version and moves to qt6. Fixes for desktop file and icon installation, so it shows up in both the .desktop file and on the trayicon itself.

One thing of note is that I've manually patched the config hash to be equal to "EMPTY" (displayed in the webui for debugging purposes), perhaps there's a better way of doing this.