### PR TITLE
azazel: init mala-zahradka-pro-radost.cz web site

### DIFF
--- a/hosts/azazel/configuration.nix
+++ b/hosts/azazel/configuration.nix
@@ -19,6 +19,7 @@ in {
     # sites
     ./fan-club-penguin.cz
     ./krk-litvinov.cz
+    ./mala-zahradka-pro-radost.cz
     ./ogion.cz
     ./ostrov-tucnaku.cz
     ./rogaining.org
@@ -101,6 +102,8 @@ in {
     defaults.email = "acme@ogion.cz";
     acceptTerms = true;
   };
+
+  security.polkit.enable = true;
 
   users = {
     users = {

--- a/hosts/azazel/mala-zahradka-pro-radost.cz/default.nix
+++ b/hosts/azazel/mala-zahradka-pro-radost.cz/default.nix
@@ -1,0 +1,38 @@
+{ config, lib, pkgs, myLib, ... }:
+let
+  inherit (myLib) mkPhpPool;
+in {
+  imports = [
+    ./www
+  ];
+
+  security.acme.certs."mala-zahradka-pro-radost.cz".extraDomainNames = [
+    "www.mala-zahradka-pro-radost.cz"
+  ];
+
+  users = {
+    users = {
+      jtojnar = {
+        extraGroups = [
+          "mzpr"
+        ];
+      };
+
+      nginx = {
+        extraGroups = [
+          "mzpr"
+        ];
+      };
+
+      mzpr = {
+        uid = 521;
+        group = "mzpr";
+        isSystemUser = true;
+      };
+    };
+
+    groups = {
+      mzpr = { gid = 521; };
+    };
+  };
+}

--- a/hosts/azazel/mala-zahradka-pro-radost.cz/www/README.md
+++ b/hosts/azazel/mala-zahradka-pro-radost.cz/www/README.md
@@ -1,0 +1,7 @@
+# mala-zahradka-pro-radost.cz
+
+This is the implementation of the operational part of <https://mala-zahradka-pro-radost.cz/> static site.
+
+User pushes changes to the [primary repo for the site on Gitea](https://code.ogion.cz/tojnar.cz/zahradka). The allotted directory `/var/www/mala-zahradka-pro-radost.cz/www` contains a secondary copy of the repo and a `current` symlink pointing to the latest secondary directory. The nginx virtual host then serves the contents of the `public` directory inside the `current`.
+
+Each time a commit is pushed to the primary repo, a *post-receive* hook runs a oneshot systemd service that duplicates the `current` repo, pulls in changes from the primary, runs the `site build` command and, if successful, points the `current` symlink to the new repo. Gitea will be informed about the status and build log will be stored publicly in the `logs` directory.

--- a/hosts/azazel/mala-zahradka-pro-radost.cz/www/default.nix
+++ b/hosts/azazel/mala-zahradka-pro-radost.cz/www/default.nix
@@ -1,0 +1,105 @@
+{ config, myLib, pkgs, ... }:
+let
+  inherit (myLib) mkVirtualHost;
+
+  vhost = config.services.nginx.virtualHosts."mala-zahradka-pro-radost.cz";
+in {
+  age.secrets = {
+    "gitea-token-jtojnar-mzpr".file = ../../../../secrets/gitea-token-jtojnar.age;
+  };
+
+  services = {
+    nginx = {
+      enable = true;
+
+      virtualHosts = {
+        "mala-zahradka-pro-radost.cz" = mkVirtualHost {
+          acme = true;
+          path = "mala-zahradka-pro-radost.cz/www";
+          config = ''
+            location / {
+              root ${vhost.root}/current/public;
+            }
+            location /logs {
+              root ${vhost.root};
+            }
+          '';
+        };
+
+        "www.mala-zahradka-pro-radost.cz" = mkVirtualHost {
+          redirect = "www.mala-zahradka-pro-radost.cz";
+          acme = "mala-zahradka-pro-radost.cz";
+        };
+      };
+    };
+  };
+
+  systemd.services."mala-zahradka-pro-radost-cz-deploy@" = {
+    script = ''
+      # Deploy log is redirected to be able to link to it.
+      logName="logs/$(date --utc "+%Y-%m-%dT%H:%M:%S").log"
+
+      # Required by Nix
+      mkdir -p .cache
+      export XDG_CACHE_HOME="$PWD/.cache"
+
+      ${pkgs.deploy-pages}/bin/deploy-pages \
+        "--site-url=https://mala-zahradka-pro-radost.cz/" \
+        "--token-path=$CREDENTIALS_DIRECTORY/token" \
+        "--owner=tojnar.cz" \
+        "--repo=zahradka" \
+        "--commit-sha=$1" \
+        "--log-url=https://mala-zahradka-pro-radost.cz/$logName" \
+        "--build-command=nix shell .#{default,vips} -c site build" \
+          2>&1 | tee "$logName"
+    '';
+    # Pass the instance argument.
+    scriptArgs = "%i";
+    serviceConfig = {
+      Type = "oneshot";
+      LoadCredential = [
+        "token:${config.age.secrets."gitea-token-jtojnar-mzpr".path}"
+      ];
+      User = config.users.users.mzpr.name;
+      WorkingDirectory = vhost.root;
+    };
+  };
+
+  nix = {
+    settings = {
+      # Allow building the site binary.
+      allowed-users = [ config.users.users.mzpr.name ];
+    };
+  };
+
+  security.polkit.extraConfig = ''
+    // Allow gitea to start the deploy service.
+    polkit.addRule(function(action, subject) {
+        if (action.id === "org.freedesktop.systemd1.manage-units"
+            // TODO: Duktape does not currently support ?. operator.
+            && (action.lookup("unit") || {match() { return false;}}).match(/^mala-zahradka-pro-radost-cz-deploy@.+\.service$/)
+            && action.lookup("verb") === "start"
+            && subject.user === "${config.services.gitea.user}") {
+            return polkit.Result.YES;
+        }
+    });
+  '';
+
+  systemd.tmpfiles.rules =
+    let
+      postReceiveHook = pkgs.writeShellScript "run-deploy" ''
+        while read oldrev newrev ref; do
+            # When on the main branch.
+            if [[ "$ref" == refs/heads/main ]]; then
+                # Start the systemd service and pass the commit sha as instance argument.
+                systemctl start "mala-zahradka-pro-radost-cz-deploy@$newrev.service" --no-block
+            else
+                echo "Not running deploy for non-main branch."
+            fi
+        done
+      '';
+    in
+    [
+      "L+ ${config.services.gitea.repositoryRoot}/tojnar.cz/zahradka.git/hooks/post-receive.d/deploy-pages - - - - ${postReceiveHook}"
+    ];
+}

--- a/hosts/azazel/ogion.cz/code/default.nix
+++ b/hosts/azazel/ogion.cz/code/default.nix
@@ -50,6 +50,9 @@ in
         server = {
           LANDING_PAGE = "explore";
         };
+        security = {
+          DISABLE_GIT_HOOKS = false;
+        };
         service = {
           DISABLE_REGISTRATION = true;
         };

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -19,6 +19,7 @@ final: prev: {
 
   inherit (prev.callPackages ./utils {})
     deploy
+    deploy-pages
     git-part-pick
     git-auto-fixup
     git-auto-squash

--- a/pkgs/utils/default.nix
+++ b/pkgs/utils/default.nix
@@ -2,6 +2,7 @@
 , callPackage
 , lib
 , makeWrapper
+, git
 , fzf
 , python3
 , nix
@@ -54,6 +55,20 @@ in {
       }))
     ];
   };
+
+  deploy-pages = mkUtil "deploy-pages" {
+    buildInputs = [
+      (python3.withPackages (pp: [
+        pp.humanize
+        pp.requests
+      ]))
+    ];
+    path = [
+      nix
+      git
+    ];
+  };
+
   git-part-pick = mkUtil "git-part-pick" { path = [ fzf ]; };
   git-auto-fixup = mkUtil "git-auto-fixup" { };
   git-auto-squash = mkUtil "git-auto-squash" { script = "git-auto-fixup"; };

--- a/pkgs/utils/deploy-pages
+++ b/pkgs/utils/deploy-pages
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2023 Jan Tojnar <jtojnar@gmail.com>
+# SPDX-License-Identifier: MIT
+
+import argparse
+from datetime import datetime, timezone
+import humanize
+from pathlib import Path
+import requests
+import subprocess
+from typing import Literal
+
+
+STATUS_CONTEXT = "deploy-pages"
+
+
+# https://docs.gitea.io/en-us/api-usage/
+class GiteaRepo:
+    def __init__(self, owner: str, repo: str, token: str):
+        self.owner = owner
+        self.repo = repo
+        self.token = token
+
+    def set_commit_status(
+        self,
+        commit_sha: str,
+        description: str,
+        state: Literal["pending", "success", "error", "failure", "warning"],
+        target_url: str,
+    ) -> None:
+        url = f"https://code.ogion.cz/api/v1/repos/{self.owner}/{self.repo}/statuses/{commit_sha}"
+        headers = {
+            "Authorization": f"token {self.token}",
+        }
+        payload = {
+            "context": STATUS_CONTEXT,
+            "description": description,
+            "state": state,
+            "target_url": target_url,
+        }
+        requests.post(
+            url,
+            json=payload,
+            headers=headers,
+        )
+
+
+def make_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "--token-path",
+        dest="token_path",
+        help="Path to the file containing Gitea API token",
+        type=Path,
+        required=True,
+    )
+
+    parser.add_argument(
+        "--owner",
+        dest="owner",
+        help="Owner of the Gitea repository",
+        required=True,
+    )
+
+    parser.add_argument(
+        "--repo",
+        dest="repo",
+        help="Name of the Gitea repository",
+        required=True,
+    )
+
+    parser.add_argument(
+        "--commit-sha",
+        dest="commit_sha",
+        help="Hash of the deployed commit",
+        required=True,
+    )
+
+    parser.add_argument(
+        "--build-command",
+        dest="build_command",
+        help="Command to run to build the site",
+        required=True,
+    )
+
+    parser.add_argument(
+        "--site-url",
+        dest="site_url",
+        help="URL of the site",
+        required=True,
+    )
+
+    parser.add_argument(
+        "--log-url",
+        dest="log_url",
+        help="URL of the build log",
+        required=True,
+    )
+
+    return parser
+
+
+def isoformat(dt: datetime) -> str:
+    """
+    ISO-8601 format without timezone or milliseconds.
+    """
+    return dt.strftime("%Y-%m-%dT%H:%M:%S")
+
+
+def main() -> None:
+    args = make_parser().parse_args()
+    start_time = datetime.now(timezone.utc)
+
+    repo = GiteaRepo(
+        owner=args.owner,
+        repo=args.repo,
+        token=args.token_path.read_text(),
+    )
+
+    commit_sha = args.commit_sha
+    site_url = args.site_url
+    log_url = args.log_url
+    build_command = args.build_command
+
+    repo.set_commit_status(
+        commit_sha=commit_sha,
+        description="Build started",
+        state="pending",
+        target_url=log_url,
+    )
+
+    repos_root = Path(".")
+    current_source_link = repos_root / "current"
+    new_source = repos_root / isoformat(start_time)
+
+    deploy_succeeded = False
+
+    try:
+        subprocess.run(
+            ["cp", "-r", current_source_link.resolve(), new_source],
+            check=True,
+        )
+
+        repo.set_commit_status(
+            commit_sha=commit_sha,
+            description="Pulling latest changes",
+            state="pending",
+            target_url=log_url,
+        )
+        subprocess.run(
+            ["git", "fetch", "origin"],
+            cwd=new_source,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "reset", "--hard", commit_sha],
+            cwd=new_source,
+            check=True,
+        )
+
+        repo.set_commit_status(
+            commit_sha=commit_sha,
+            description="Building site",
+            state="pending",
+            target_url=log_url,
+        )
+        # Update site.
+        subprocess.run(
+            build_command,
+            cwd=new_source,
+            shell=True,
+            check=True,
+        )
+
+        # Try to reduce the chance of race condition.
+        current_source = current_source_link.resolve()
+        current_source_dt = datetime.fromisoformat(current_source.stem + "+00:00")
+        if current_source_dt < start_time:
+            # Atomically switch the current source to the new directory.
+            subprocess.run(
+                ["ln", "-sfn", new_source, current_source_link],
+                check=True,
+            )
+            deploy_succeeded = True
+
+            end_time = datetime.now(timezone.utc)
+            duration = humanize.naturaldelta(end_time - start_time)
+
+            repo.set_commit_status(
+                commit_sha=commit_sha,
+                description=f"Deployed in {duration}",
+                state="success",
+                target_url=site_url,
+            )
+        else:
+            repo.set_commit_status(
+                commit_sha=commit_sha,
+                description="Not deployed, a newer version is already present.",
+                state="warning",
+                target_url=site_url,
+            )
+    except:
+        repo.set_commit_status(
+            commit_sha=commit_sha,
+            description="Failed to deploy",
+            state="failure",
+            target_url=log_url,
+        )
+        raise
+    finally:
+        # Clean up the unused directory.
+        subprocess.run(
+            ["rm", "-rf", current_source if deploy_succeeded else new_source],
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/secrets/gitea-token-jtojnar.age
+++ b/secrets/gitea-token-jtojnar.age
@@ -1,0 +1,15 @@
+age-encryption.org/v1
+-> ssh-ed25519 y9dNJA ovnfwI27G9uvUrRtTlZtArswWnVftWQiI4pVbychJkE
+GknND7oKgOpLq5PnnuPqJYr6SeTnMozz3unMSvCbYy0
+-> ssh-rsa hco4Zg
+fqFndooeucJvmlt1Mjqc/Wk31IugXMqw2XUvx2c8gDryMeiIlyOn2TCs/Uv99tCT
+awQ5anCRATfS4Tct4vkZAKXrq15Lc+tQqnuDii2X3aa+Oho1De5np8a4hZVMYR/6
+me/mKv3XkufLAmn4JwZww55RF5hR+SCSHN48bZ2vSJ2vD1MWvVgazA+JGlMIq0MW
+kJVgbOGuVS+yzVF6cSeRs+DURFDD1S6Jpe0cAqOj22VTogJ1fTDFeZXDxPGMeR2P
+7tE/9pblh9oUSH7fO36ScJhcLitDR8/XlLbGq9Z0BUZlrg63dhc8rci9QlE8WwpG
+KJ4giOPaRQYheUmWCUDDtg
+-> M\wW/^--grease wCiV#Po *fV^Wr mQ>}W:?
+KpAcQrPUsU1Dgyy1kciUv8fARhMXBJql5slBRtTXwVjJTRtgBLrUUmlIpH+oMevk
+dazBN1sh3qTxqBMt4MYxN0XGBdj8YEyvf8U
+--- qjCkB3m3SIwqMmGYiZG9tzMPDV0bwa3rspRUOxbyA5g
+îXŸ\Ôr¯f™ŸÇ_oÄÆ+‡F eãÎ¿ÈPŠÊŞO‡{:)ãåÄ/O“Ï4†y>ë}yß_®²hkÍñeôÈak

--- a/secrets/secrets.nix
+++ b/secrets/secrets.nix
@@ -16,4 +16,9 @@ in
 
     keys.jtojnar
   ];
+  "gitea-token-jtojnar.age".publicKeys = builtins.concatLists [
+    keys.azazel
+
+    keys.jtojnar
+  ];
 }


### PR DESCRIPTION
This commit sets up a pipeline for building https://mala-zahradka-pro-radost.cz/ using static site generator and then serving it:

1. Adds a virtual host for the site.
2. Creates a `deploy-pages` program that, when executed, generates the site content and updates the web root. It also notifies Gitea of the progress.
3. Stores Gitea token into the repo as an agenix secret (created as “pages-deploy” API key by jtojnar in https://code.ogion.cz/user/settings/applications).
4. Registers a systemd service that calls the `deploy-pages` program.
5. Enables Polkit and sets up a rule that will allow Gitea to run the service.
6. Adds a git post-receive hook that calls the aforementioned service whenever user pushes to the Gitea repo.

I needed to manually prepare the working repository:

    mkdir -p /var/www/mala-zahradka-pro-radost.cz/www
    git clone "https://code.ogion.cz/tojnar.cz/zahradka.git" "/var/www/mala-zahradka-pro-radost.cz/www/$(date --iso-8601)"
    ln -s  "/var/www/mala-zahradka-pro-radost.cz/www/$(date --iso-8601)" "/var/www/mala-zahradka-pro-radost.cz/www/current"
    mkdir "/var/www/mala-zahradka-pro-radost.cz/www/current/public"
    mkdir "/var/www/mala-zahradka-pro-radost.cz/www/logs"
    sudo chown -R mzpr:mzpr "/var/www/mala-zahradka-pro-radost.cz"
